### PR TITLE
Remove sphinxcontrib-napoleon from conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,5 @@ dependencies:
   - python=3.7
   - pytest
   - sphinx
-  - sphinxcontrib-napoleon
   - black
   - flake8


### PR DESCRIPTION
This is now included in the sphinx.

Closes #ISSUE_NUMBER

- [ ] Test code (i.e. unittest, pytest, etc.)
- [ ] Flake8 compliant
- [ ] Tag commit
- [ ] Request Review @ENTER_MAINTAINER
